### PR TITLE
Use current Mentat with better imports.

### DIFF
--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -13,12 +13,13 @@ crate-type = ["dylib"]
 neon-build = "0.1.14"
 
 [dependencies]
+chrono = "0.3"
 neon = "0.1.14"
-mentat = { git = "https://github.com/mozilla/mentat", rev = "e64ee5864eb4486b91d2ad8b51a2358dec5af700"}
-mentat_db = { git = "https://github.com/mozilla/mentat", rev = "e64ee5864eb4486b91d2ad8b51a2358dec5af700" }
-mentat_core = { git = "https://github.com/mozilla/mentat", rev = "e64ee5864eb4486b91d2ad8b51a2358dec5af700" }
+mentat = { git = "https://github.com/mozilla/mentat", rev = "1dc8a3e"}
+mentat_db = { git = "https://github.com/mozilla/mentat", rev = "1dc8a3e" }
+mentat_core = { git = "https://github.com/mozilla/mentat", rev = "1dc8a3e" }
 
 [dependencies.rusqlite]
-version = "0.10.1"
+version = "0.11"
 # System sqlite might be very old.
 features = ["bundled", "limits"]


### PR DESCRIPTION
This doesn't build for me — Neon complains about not having x64 symbols. But it should be right.

Need to figure out how to call `new Date(timestamp)`.